### PR TITLE
feat: add prop color in typography component

### DIFF
--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -25,7 +25,7 @@
 
   &__content {
     display: flex;
-    flex-direction: column; 
+    flex-direction: column;
     gap: 8px;
 
     @media screen and (min-width: 960px) {
@@ -50,7 +50,6 @@
     }
 
     &__error {
-      color: var(--color-red);
       margin-top: 4px;
     }
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -155,7 +155,11 @@ const Home = () => {
               </Button>
             </div>
             {subscribeError && (
-              <Typography variant="bodySmall" className={classes.error}>
+              <Typography
+                variant="bodySmall"
+                color="error"
+                className={classes.error}
+              >
                 Esse email já está cadastrado.
               </Typography>
             )}

--- a/src/components/Form/Checkbox/Checkbox.module.scss
+++ b/src/components/Form/Checkbox/Checkbox.module.scss
@@ -1,6 +1,6 @@
 .c-checkbox {
   margin: 8px 0;
-  
+
   &__container {
     cursor: pointer;
     display: block;
@@ -27,7 +27,7 @@
     width: 16px;
 
     &::after {
-      content: "";
+      content: '';
       display: none;
       position: absolute;
     }
@@ -56,7 +56,6 @@
   }
 
   &__error {
-    color: var(--color-red);
     font-size: 12px;
     margin-top: 0;
   }

--- a/src/components/Form/Checkbox/Checkbox.tsx
+++ b/src/components/Form/Checkbox/Checkbox.tsx
@@ -45,7 +45,12 @@ const Checkbox = forwardRef<HTMLInputElement, TProps>(
           {label}
           <span className={classes.checkmark} />
         </label>
-        <Typography variant="small" as="small" className={classes.error}>
+        <Typography
+          variant="small"
+          as="small"
+          color="error"
+          className={classes.error}
+        >
           {error}
         </Typography>
       </div>

--- a/src/components/Form/Input/Input.module.scss
+++ b/src/components/Form/Input/Input.module.scss
@@ -24,8 +24,4 @@
       text-align: center;
     }
   }
-
-  &__error {
-    color: var(--color-red);
-  }
 }

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -21,7 +21,6 @@ const Input = forwardRef<HTMLInputElement, TProps>(
       default: classNames(styles['c-input']),
       container: classNames(styles['c-input__container']),
       input: classNames(styles['c-input__input']),
-      error: classNames(styles['c-input__error']),
     };
 
     return (
@@ -44,7 +43,7 @@ const Input = forwardRef<HTMLInputElement, TProps>(
         </div>
 
         {error && (
-          <Typography variant="small" as="small" className={classes.error}>
+          <Typography variant="small" as="small" color="error">
             {error}
           </Typography>
         )}

--- a/src/components/Typography/Typography.module.scss
+++ b/src/components/Typography/Typography.module.scss
@@ -79,7 +79,6 @@
     text-align: right;
   }
 
-
   // Transforms
   &--lowercase {
     text-transform: lowercase;
@@ -87,6 +86,31 @@
 
   &--uppercase {
     text-transform: uppercase;
+  }
+
+  // Colors
+  &--primary {
+    color: var(--color-purple-blue);
+  }
+
+  &--secondary {
+    //TODO: Confirmar cor secundária!
+  }
+
+  &--error {
+    color: var(--color-red);
+  }
+
+  &--info {
+    color: var(--color-blue);
+  }
+
+  &--success {  
+    color: var(--color-green);
+  }
+
+  &--warning {
+    color: var(--color-yellow);
   }
 }
 

--- a/src/components/Typography/Typography.test.tsx
+++ b/src/components/Typography/Typography.test.tsx
@@ -7,6 +7,7 @@ import Typography, {
   TAlignments,
   TStylings,
   TTransforms,
+  TColors,
 } from './Typography';
 
 const defaultProps = {
@@ -15,6 +16,7 @@ const defaultProps = {
   align: 'right' as TAlignments,
   styling: 'normal' as TStylings,
   transform: 'uppercase' as TTransforms,
+  color: 'primary' as TColors,
   className: '',
   children: 'Default Text',
 };
@@ -77,6 +79,17 @@ describe('<Typography />', () => {
     });
     const element = screen.getByText(/text/i);
     expect(element).toHaveClass('c-typography--uppercase');
+  });
+
+  it('should apply color class correctly', () => {
+    const text = 'Uppercase Text';
+    setup({
+      ...defaultProps,
+      color: 'error',
+      children: text,
+    });
+    const element = screen.getByText(/text/i);
+    expect(element).toHaveClass('c-typography--color-error');
   });
 
   it('should accept additional className', () => {

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -76,11 +76,23 @@ const transforms = {
 
 export type TTransforms = keyof typeof transforms;
 
+const colors = {
+  primary: 'primary',
+  secondary: 'secondary',
+  error: 'error',
+  info: 'info',
+  success: 'success',
+  warning: 'warning',
+} as const;
+
+export type TColors = keyof typeof colors;
+
 type Props = {
   variant?: TVariants;
   align?: TAlignments;
   styling?: TStylings;
   transform?: TTransforms;
+  color?: TColors;
   className?: string;
   children: ReactNode;
 } & TConditionalProps;
@@ -92,8 +104,9 @@ const Typography: FC<Props> = (
     align,
     styling,
     transform,
-    children,
+    color = 'primary',
     className,
+    children,
   },
   props,
 ) => {
@@ -105,6 +118,7 @@ const Typography: FC<Props> = (
         [styles[`c-typography--${align}`]]: align,
         [styles[`c-typography--${styling}`]]: styling,
         [styles[`c-typography--${transform}`]]: transform,
+        [styles[`c-typography--color-${color}`]]: color,
       }),
       ...props,
     },


### PR DESCRIPTION
# [EH-95](https://squadmercurio.atlassian.net/browse/EH-95) | [FE] Adicionar a prop color no componente de Typography

> Essa tarefa está relacionada a [HU004 - Visualizar lista de Funcionalidades](https://squadmercurio.atlassian.net/browse/EH-62)

## Descrição  
<!-- Adicione um breve resumo do que foi desenvolvido através dessa Pull Request. Se achar relevante, inclua uma imagem referente ao contexto implementado.  -->

Atualmente, para adicionar uma cor diferente do default no componente de tipografia, é necessário usar classes de estilo. 

Então, nessa tarefa iremos adicionar a prop color para o componente e replicar essa alteração nos locais que estão sendo utilizados da maneira comentada anteriormente. 


<!-- 
  Caso queira adicionar um antes e depois com tabela:

  | antes | depois |
  | -     | -      | 
  | imgA  | imgB   |

 -->

## Tipo de mudança

<!-- Por gentileza, exclua as opções que não são relevantes. -->

- [x] Nova funcionalidade (*non-breaking change*, apenas adição de funcionalidade)


## Checklist

Revise as [guidelines](../CONTRIBUTING.md) deste projeto antes de contribuir. 

- [x] Minha Pull Request foi aberta com referência a branch *main*;
- [x] As mensagens dos meus commits estão seguindo a [Convetional Commits](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] Fiz alterações no código e as documentei;
- [x] Adicionei novos testes para a *feature* ou *fix*.

