### PR TITLE
fix: adjust lint-staged path and order of imports of some components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint:fix": "eslint --fix",
     "prettier:check": "prettier --check '**/*.{ts,tsx,json,yml}'",
     "prettier:fix": "prettier --write '**/*.{ts,tsx,json,yml}'",
     "test": "jest --verbose --no-cache",
@@ -15,10 +15,13 @@
     "test:coverage": "jest --coverage --no-cache"
   },
   "lint-staged": {
-    "src/app/**/*.(ts|tsx)": [
+    "*.{ts,tsx}": [
       "npm run prettier:fix",
       "npm run lint:fix",
       "jest --findRelatedTests --bail"
+    ],
+    "*.{json,md,yml,scss}": [
+      "npm run prettier:fix"
     ]
   },
   "dependencies": {

--- a/src/components/Form/Input/Input.tsx
+++ b/src/components/Form/Input/Input.tsx
@@ -1,7 +1,9 @@
-import Typography from '@/components/Typography';
-import { forwardRef, InputHTMLAttributes, ReactElement } from 'react';
-import styles from './Input.module.scss';
 import classNames from 'classnames';
+import { forwardRef, InputHTMLAttributes, ReactElement } from 'react';
+
+import Typography from '@/components/Typography';
+
+import styles from './Input.module.scss';
 
 type TProps = {
   id: string;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,8 +1,9 @@
 import { FC, PropsWithChildren, useCallback } from 'react';
 import classNames from 'classnames';
 
-import styles from './Modal.module.scss';
 import Button from '../Form/Button';
+
+import styles from './Modal.module.scss';
 
 type TProps = {
   closeByIcon?: boolean;


### PR DESCRIPTION


## Descrição  
<!-- Adicione um breve resumo do que foi desenvolvido através dessa Pull Request. Se achar relevante, inclua uma imagem referente ao contexto implementado.  -->

Esta PR corrige o script do `lint-staged` ao adicionar novos commits. Além disso, também ajustei a ordem dos _imports_ de alguns componentes para seguir o padrão de: lib > components > styles. 


<!-- 
  Caso queira adicionar um antes e depois com tabela:

  | antes | depois |
  | -     | -      | 
  | imgA  | imgB   |

 -->

## Tipo de mudança

<!-- Por gentileza, exclua as opções que não são relevantes. -->

- [x] Bug Fix (*non-breaking change*, apenas corrige um problema)

## Checklist

Revise as [guidelines](../CONTRIBUTING.md) deste projeto antes de contribuir. 

- [x] Minha Pull Request foi aberta com referência a branch *main*;
- [x] As mensagens dos meus commits estão seguindo a [Convetional Commits](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] Fiz alterações no código e as documentei.


